### PR TITLE
Mark the number entities as `DIAGNOSTIC`.

### DIFF
--- a/custom_components/green_button/number.py
+++ b/custom_components/green_button/number.py
@@ -13,6 +13,7 @@ from homeassistant.components import number
 from homeassistant.components.recorder import util as recorder_util
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -27,12 +28,14 @@ _LOGGER = logging.getLogger(__name__)
 
 _MOST_RECENT_ENERGY_READING_NUMBER_DESCRIPTION = number.NumberEntityDescription(
     key="green_button_last_energy_reading",
+    entity_category=entity.EntityCategory.DIAGNOSTIC,
     native_step=1,
     icon="mdi:lightning-bolt",
 )
 
 _MOST_RECENT_COST_READING_NUMBER_DESCRIPTION = number.NumberEntityDescription(
     key="green_button_most_recent_cost_reading",
+    entity_category=entity.EntityCategory.DIAGNOSTIC,
     native_step=float(10**-5),  # Hundred thousandth
     icon="mdi:cash",
 )


### PR DESCRIPTION
This will prevent HA from showing the entity in the overview dashboard.